### PR TITLE
Added functionality to repos form

### DIFF
--- a/main.js
+++ b/main.js
@@ -223,6 +223,33 @@ const getPinnedRepoFormInfo = (e) => {
   form.reset();
 };
 
+// Function to submit new Repo Form 
+const newRepoForm = (e) => {
+  e.preventDefault();
+  console.log('Welcome to the machine')
+
+  const repoName = document.querySelector('#repoName').value;
+  const repoDescription = document.querySelector('#repoDescription').value;
+  const repoTags = ['Test'];
+  const isPinned = false;
+
+  // Store form data in obj
+
+  const repoObj = {
+    repoName,
+    repoDescription,
+    repoTags,
+    isPinned
+  }
+  users[0].repos.push(repoObj);
+
+  // Re-render the repos on DOM //
+  repoBuilders(users);
+
+  // Reset the form //
+  document.querySelector('form').reset();
+}
+
 // Get Package Form Info
 // const packageForm = (e) => {
 //   e.preventDefault();
@@ -243,11 +270,14 @@ const getPinnedRepoFormInfo = (e) => {
 // };
 // End Get Package Form Info
 // *** Event Listeners *** //
-
-  const handleButtonEvents = () => {
-    document.querySelector('#pinnedReposForm').addEventListener('submit',getPinnedRepoFormInfo);
-  };
-
+  // Index Event Listener //
+const handleButtonEventsIndex = () => {
+  document.querySelector('#pinnedReposForm').addEventListener('submit',getPinnedRepoFormInfo);
+};
+  // Repos Event Listener //
+const handleButtonEventsRepos = () => {
+  document.querySelector('#reposForm').addEventListener('submit', newRepoForm)
+};  
 
 // *** Initializers *** //
 const init = () => {
@@ -255,11 +285,12 @@ const init = () => {
     createPackage(users);
     } else if (window.location.pathname === "/repositories.html") {
     repoBuilders(users);
+    handleButtonEventsRepos();
     } else if (window.location.pathname === '/projects.html') {
     projectBuilder(users);
     } else {
     pinnedRepoBuilder(users);
-    handleButtonEvents();
+    handleButtonEventsIndex();
     }
   };
 

--- a/main.js
+++ b/main.js
@@ -226,7 +226,6 @@ const getPinnedRepoFormInfo = (e) => {
 // Function to submit new Repo Form 
 const newRepoForm = (e) => {
   e.preventDefault();
-  console.log('Welcome to the machine')
 
   const repoName = document.querySelector('#repoName').value;
   const repoDescription = document.querySelector('#repoDescription').value;

--- a/repositories.html
+++ b/repositories.html
@@ -90,7 +90,7 @@
     </div>  
     <!-- Form to add new repo -->
     <div class="form-container m-3">FORM
-      <form>
+      <form id="reposForm">
         <div class="mb-3">
           <h5>Create a new repository</h5>
           <hr />


### PR DESCRIPTION
Added functionality to Repos Form

## Description
When a user submits data on the repos page, a new repo is rendered on the DOM. 

## Related Issue
fixes #31 

## Motivation and Context
This will allow users to dynamically add repos to the page when submitting the form. 

## How Can This Be Tested?
hs -o, click the Repositories link in the navbar. 
Scroll down to the form, input a repo name and description, submit. 
If working properly, the new form should render. 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
