### PR TITLE
Added option to add tags to the Create Repos Form

### DIFF
--- a/repositories.html
+++ b/repositories.html
@@ -51,10 +51,10 @@
       <hr /> -->
     </div>  
     <!-- Form to add new repo -->
-    <div class="form-container m-3">FORM
+    <div class="form-container m-3">
       <form id="reposForm">
         <div class="mb-3">
-          <h5>Create a new repository</h5>
+          <h4>Create a new repository</h4>
           <hr />
           <label for="repoName" class="form-label">Repository Name</label>
           <input type="text" class="form-control" id="repoName" aria-describedby="repoHelp" required>
@@ -64,7 +64,19 @@
           <label for="repoDescription" class="form-label">Description (optional)</label>
           <input type="text" class="form-control" id="repoDescription">
         </div>
-        <button type="submit" class="btn btn-primary">Create repository</button>
+        <div class="row">
+          <div class="col">
+            <input type="text" class="form-control" placeholder="Tag 1" aria-label="Tag 1">
+          </div>
+          <div class="col">
+            <input type="text" class="form-control" placeholder="Tag 2" aria-label="Tag 2">
+          </div>
+          <div class="col">
+            <input type="text" class="form-control" placeholder="Tag 3" aria-label="Tag 3">
+          </div>
+          <div id="repoHelp" class="form-text">Tags are optional, but useful!</div>
+        </div>
+        <button type="submit" class="btn btn-primary mt-2">Create repository</button>
       </form>
     </div>
   </div>


### PR DESCRIPTION
Added option to add tags to the Create Repos Form

## Description
Users will need the option to add tags to newly created repos. HTML placeholder for inputs are now in form. 

## Related Issues
fixes #82

## Motivation and Context
This will allow us to put JS event listeners on these tags and dynamically create an array of tags on new repo creation.
Required for #83 

## How Can This Be Tested?
hs -o, click repositories link in navbar. Check the Create New Repos form, there is now a place to add 3 Tags. 
- HTML only, JS functionality will be added next. 

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
